### PR TITLE
Add indentation support and add some missing keywords

### DIFF
--- a/indent/wgsl.vim
+++ b/indent/wgsl.vim
@@ -1,0 +1,34 @@
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal autoindent
+setlocal nolisp
+setlocal nosmartindent
+setlocal indentexpr=WgslIndent(v:lnum)
+
+function! WgslIndent(lnum)
+  if a:lnum == 1
+    return 0
+  endif
+
+  let l:indent = indent(a:lnum)
+  let l:prev_line = getline(a:lnum - 1)
+  let l:line = getline(a:lnum)
+
+  " Ending with {, (, or [
+  if l:prev_line =~# '^.*\({\|(\|[\)\s*$'
+    if l:line =~# '^\s*$'
+      return l:indent + &shiftwidth
+    endif
+  endif
+
+  return l:indent
+endfunc
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -44,6 +44,7 @@ syn region wgslCommentLine start="//" end="$"
 
 " Builtin Variables
 syn keyword wgslBuiltinVariables vertex_index instance_index
+syn keyword wgslBuiltinVariables position
 syn keyword wgslBuiltinVariables frag_coord front_facing frag_depth
 syn keyword wgslBuiltinVariables local_invocation_id local_invocation_index global_invocation_id workgroup_id workgroup_size
 syn keyword wgslBuiltinVariables sample_index sample_mask_in smaple_mask_out
@@ -66,8 +67,9 @@ syn keyword wgslDataPackingBuiltinFunctions unpack4x8snorm unpack4x8unorm unpack
 
 
 " Keyword
-syn keyword wgslKeywords var
-syn keyword wgslKeywords location stage vertex fragment builtin
+syn keyword wgslKeywords let var
+syn keyword wgslKeywords block builtin fragment location stage vertex
+syn keyword wgslKeywords break continue discard for if loop return switch
 syn keyword wgslKeywords fn nextgroup=wgslFuncName skipwhite skipempty
 syn keyword wgslKeywords location nextgroup=wgslLocation skipwhite skipempty
 syn keyword wgslKeywords binding nextgroup=wgslLocation skipwhite skipempty

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -65,19 +65,19 @@ syn keyword wgslBuiltinTextureFunctions  textureSampleBias textureSampleCompare 
 syn keyword wgslDataPackingBuiltinFunctions pack4x8snorm pack4x8unorm pack2x16snorm pack2x16unorm pack2x16float
 syn keyword wgslDataPackingBuiltinFunctions unpack4x8snorm unpack4x8unorm unpack2x16snorm unpack2x16unorm unpack2x16float
 
+syn keyword wgslAttributes binding block builtin fragment group location stage vertex
 
 " Keyword
+syn keyword wgslKeywords fn
 syn keyword wgslKeywords let var
-syn keyword wgslKeywords block builtin fragment location stage vertex
 syn keyword wgslKeywords break continue discard for if loop return switch
-syn keyword wgslKeywords fn nextgroup=wgslFuncName skipwhite skipempty
-syn keyword wgslKeywords location nextgroup=wgslLocation skipwhite skipempty
-syn keyword wgslKeywords binding nextgroup=wgslLocation skipwhite skipempty
-syn keyword wgslKeywords group nextgroup=wgslLocation skipwhite skipempty
-syn match wgslFuncName "\%(r#\)\=\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
-syn match wgslLocation "\%(\d\)"
 
 syn match wgslFuncCall    "\w\(\w\)*("he=e-1,me=e-1
+
+syntax match wgslNumber "\v<\d+>"
+syntax match wgslNumber "\v<(\d+_+)+\d+(\.\d+(_+\d+)*)?>"
+syntax match wgslNumber "\v<\d+\.\d+>"
+syntax match wgslNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
 
 hi def link wgslTypes Type
 hi def link wgslNumberTypes Float
@@ -90,12 +90,14 @@ hi def link wgslSamplerTypes Type
 hi def link wgslBuiltinVariables Identifier
 hi def link wgslBuiltinFunctions Function
 hi def link wgslBuiltinTextureFunctions Function
-hi def link wgslFuncName Function
 hi def link wgslFuncCall Function
 
+hi def link wgslAttributes Keyword
 hi def link wgslKeywords Keyword
 hi def link wgslLocation Number
 
 hi def link wgslCommentLine Comment
+
+hi def link wgslNumber Number
 
 let b:current_syntax = "wgsl"


### PR DESCRIPTION
This PR contains basic indentation support and a few missing keywords from the latest spec. There are still plenty of missing keywords but I don't have time to go further than this right now. I found that the `wgslLocation` rule was clobbering all integers so I removed it in favour of dedicated number matching.