### PR TITLE
Use `:setfiletype` for setting filetype when no filetype is set yet

### DIFF
--- a/ftdetect/wgsl.vim
+++ b/ftdetect/wgsl.vim
@@ -1,7 +1,1 @@
-autocmd BufRead,BufNewFile *.wgsl call s:set_wgsl_filetype()
-
-function! s:set_wgsl_filetype() abort
-    if &filetype !=# 'wgsl'
-        set filetype=wgsl
-    endif
-endfunction
+autocmd BufRead,BufNewFile *.wgsl setfiletype wgsl


### PR DESCRIPTION
To avoid overwriting filetype, `:setfiletype` is a built-in command. This PR uses it instead of the user-defined function which does almost same. 

https://github.com/vim/vim/blob/15d9890eee53afc61eb0a03b878a19cb5672f732/runtime/doc/options.txt#L376-L385