### PR TITLE
Fix highlighting number and bool literals

### DIFF
--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -75,8 +75,12 @@ syn keyword wgslKeywords break continue discard for if loop return switch
 
 syn match wgslFuncCall    "\w\(\w\)*("he=e-1,me=e-1
 
-syntax match wgslNumber "\v<\d+(\.\d+)?([Ee][-+]?\d+)?>"
-syntax match wgslNumber "\v\.\d+([Ee][-+]?\d+)?>"
+" Float
+syntax match wgslNumber "\v<\d+[Ee][-+]?\d+>"
+syntax match wgslNumber "\v\d*\.\d+([Ee][-+]?\d+)?>"
+
+" Integer
+syntax match wgslNumber "\v<\d+u?>"
 
 hi def link wgslTypes Type
 hi def link wgslNumberTypes Float

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -76,11 +76,14 @@ syn keyword wgslKeywords break continue discard for if loop return switch
 syn match wgslFuncCall    "\w\(\w\)*("he=e-1,me=e-1
 
 " Float
-syntax match wgslNumber "\v<\d+[Ee][-+]?\d+>"
-syntax match wgslNumber "\v\d*\.\d+([Ee][-+]?\d+)?>"
+syntax match wgslNumber "\v<\d+(\.\d+)?([Ee][-+]?\d+)?>"
+syntax match wgslNumber "\v\.\d+([Ee][-+]?\d+)?>"
+syntax match wgslNumber "\v<0x\x+(\.\x+)?([Pp][-+]?\d+)?>"
+syntax match wgslNumber "\v<0x\.\x+([Pp][-+]?\d+)?>"
 
 " Integer
-syntax match wgslNumber "\v<\d+u?>"
+syntax match wgslNumber "\v<\d+u>"
+syntax match wgslNumber "\v<0x\x+u>"
 
 hi def link wgslTypes Type
 hi def link wgslNumberTypes Float

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -75,10 +75,8 @@ syn keyword wgslKeywords break continue discard for if loop return switch
 
 syn match wgslFuncCall    "\w\(\w\)*("he=e-1,me=e-1
 
-syntax match wgslNumber "\v<\d+>"
-syntax match wgslNumber "\v<(\d+_+)+\d+(\.\d+(_+\d+)*)?>"
-syntax match wgslNumber "\v<\d+\.\d+>"
-syntax match wgslNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
+syntax match wgslNumber "\v<\d+(\.\d+)?([Ee][-+]?\d+)?>"
+syntax match wgslNumber "\v\.\d+([Ee][-+]?\d+)?>"
 
 hi def link wgslTypes Type
 hi def link wgslNumberTypes Float

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -17,6 +17,7 @@ syn keyword wgslTypes array
 " TODO: match struct
 syn keyword wgslTypes struct
 syn keyword wgslTypes type
+syn keyword wgslTypes atomic
 " TODO: since token 'handle' is reserved and it's never used in a wgsl
 " program, shoud we set this to a keyword?
 syn keyword wgslStorageClasses handle

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -85,6 +85,9 @@ syntax match wgslNumber "\v<0x\.\x+([Pp][-+]?\d+)?>"
 syntax match wgslNumber "\v<\d+u>"
 syntax match wgslNumber "\v<0x\x+u>"
 
+" Boolean
+syntax keyword wgslBoolean true false
+
 hi def link wgslTypes Type
 hi def link wgslNumberTypes Float
 hi def link wgslStorageClasses Type
@@ -105,5 +108,6 @@ hi def link wgslLocation Number
 hi def link wgslCommentLine Comment
 
 hi def link wgslNumber Number
+hi def link wgslBoolean Boolean
 
 let b:current_syntax = "wgsl"


### PR DESCRIPTION
Following the spec: https://www.w3.org/TR/WGSL/#literals

This PR fixes the following highlights

- Decimal float
- Hex float
- Deciaml int/uint
- Hex int/uint
- Bool

I confirmed the correctness as follows (red is a color of constants in my colorscheme):

<img width="150" alt="スクリーンショット 2021-11-08 23 41 51" src="https://user-images.githubusercontent.com/823277/140762112-f9a6b76a-a38c-4747-af80-52302fe7f4af.png">

Here is a test case I used:

```
123e123
123E123
123e+123
123E+123
123e-123
123E-123

123.123e123
123.123e-123
123.123e+123
123.123E123
123.123E-123
123.123E+123

0xf1p123
0xf1p+123
0xf1p-123
0xf1P123
0xf1P+123
0xf1P-123

0xf1.f1p123
0xf1.f1p+123
0xf1.f1p-123
0xf1.f1P123
0xf1.f1P+123
0xf1.f1P-123

.123
.123e123
.123e-123
.123e+123
.123E-123
.123E+123

0x.f1
0x.f1p123
0x.f1p+123
0x.f1p-123
0x.f1P123
0x.f1P+123
0x.f1P-123

123
123u
0xff
0xffu

true
false
```
