### PR TITLE
Decrease indent on closing `}`

### DIFF
--- a/indent/wgsl.vim
+++ b/indent/wgsl.vim
@@ -27,6 +27,11 @@ function! WgslIndent(lnum)
     endif
   endif
 
+  " Ending with }
+  if l:line =~# '^\s*}\s*$'
+    return l:indent - &shiftwidth
+  endif
+
   return l:indent
 endfunc
 

--- a/indent/wgsl.vim
+++ b/indent/wgsl.vim
@@ -3,13 +3,18 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
-
 setlocal autoindent
 setlocal nolisp
 setlocal nosmartindent
 setlocal indentexpr=WgslIndent(v:lnum)
+
+" Only define the function once.
+if exists("*WgslIndent")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
 
 function! WgslIndent(lnum)
   if a:lnum == 1


### PR DESCRIPTION
This PR adds support for automatically decreasing the indent on closing `}`. Here is a screenshot:
![tmp](https://user-images.githubusercontent.com/823277/148640730-8428e8a8-6cc3-4826-bfba-fbe2a929aa9c.gif)

And `WgslIndent` function is now only defined once to make loading this ftplugin faster. Current implementation redefines the function on each time.