### PR TITLE
Update to support some newer syntax

### DIFF
--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -11,8 +11,14 @@ syn keyword wgslTypes void
 syn keyword wgslNumberTypes u32 i32 f32 bool
 " TODO: match the whole vecN<T> pattern
 syn keyword wgslTypes vec2 vec3 vec4
+syn keyword wgslTypes vec2f vec3f vec4f
+syn keyword wgslTypes vec2u vec3u vec4u
+syn keyword wgslTypes vec2i vec3i vec4i
 " TODO mat2x2 and 432 has different syntax
 syn keyword wgslTypes mat2x2 mat2x3 mat2x4 mat3x2 mat3x3 mat3x4 mat4x2 mat4x3 mat4x4
+syn keyword wgslTypes mat2x2f mat2x3f mat2x4f mat3x2f mat3x3f mat3x4f mat4x2f mat4x3f mat4x4f
+syn keyword wgslTypes mat2x2u mat2x3u mat2x4u mat3x2u mat3x3u mat3x4u mat4x2u mat4x3u mat4x4u
+syn keyword wgslTypes mat2x2i mat2x3i mat2x4i mat3x2i mat3x3i mat3x4i mat4x2i mat4x3i mat4x4i
 syn keyword wgslTypes array
 " TODO: match struct
 syn keyword wgslTypes struct

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -108,6 +108,7 @@ hi def link wgslSamplerTypes Type
 hi def link wgslBuiltinVariables Identifier
 hi def link wgslBuiltinFunctions Function
 hi def link wgslBuiltinTextureFunctions Function
+hi def link wgslDataPackingBuiltinFunctions Function
 hi def link wgslFuncCall Function
 
 hi def link wgslAttributes Keyword

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -75,11 +75,11 @@ syn keyword wgslBuiltinTextureFunctions  textureSampleBias textureSampleCompare 
 syn keyword wgslDataPackingBuiltinFunctions pack4x8snorm pack4x8unorm pack2x16snorm pack2x16unorm pack2x16float
 syn keyword wgslDataPackingBuiltinFunctions unpack4x8snorm unpack4x8unorm unpack2x16snorm unpack2x16unorm unpack2x16float
 
-syn match wgslAttributes "@ *\(align\|binding\|builtin\|const\|diagnostic\|group\|id\|interpolate\|invariant\|location\|must_use\|size\|workgroup_size\|vertex\|fragment\|compute\)"
+syn match wgslAttributes "@ *\(alias\|align\|binding\|builtin\|const\|diagnostic\|group\|id\|interpolate\|invariant\|location\|must_use\|size\|workgroup_size\|vertex\|fragment\|compute\)"
 
 " Keyword
 syn keyword wgslKeywords fn
-syn keyword wgslKeywords const let var override
+syn keyword wgslKeywords const let var override alias
 syn keyword wgslKeywords break continue discard for if else loop return switch case bitcast fallthrough
 
 syn match wgslFuncCall    "\w\(\w\)*("he=e-1,me=e-1

--- a/syntax/wgsl.vim
+++ b/syntax/wgsl.vim
@@ -29,6 +29,7 @@ syn keyword wgslTypes atomic
 syn keyword wgslStorageClasses handle
 syn keyword wgslStorageClasses function private workgroup uniform storage handle
 syn keyword wgslPointerTypes ptr ref
+syn keyword wgslAccessMode read write read_write
 
 " Texel Format
 syn keyword wgslTexelFormat R8UNORM R8SNORM R8UINT R8SINT R16UINT R16SINT R16FLOAT RG8UNORM
@@ -111,6 +112,7 @@ hi def link wgslFuncCall Function
 
 hi def link wgslAttributes Keyword
 hi def link wgslKeywords Keyword
+hi def link wgslAccessMode Keyword
 hi def link wgslLocation Number
 
 hi def link wgslCommentLine Comment


### PR DESCRIPTION
I've updated it with support for the newer shorthand syntax like `vec3f` as well as some other keywords here and there.